### PR TITLE
Fix Loq run detection rules

### DIFF
--- a/rundetection/ingestion/extracts.py
+++ b/rundetection/ingestion/extracts.py
@@ -42,10 +42,10 @@ def loq_extract(job_request: JobRequest, dataset: Any) -> JobRequest:
     :return: The updated job request
     """
     job_request.additional_values["cycle_string"] = get_cycle_string_from_path(job_request.filepath)
-    job_request.additional_values["sample_thickness"] = dataset.get("sample").get("thickness")
-    job_request.additional_values["sample_geometry"] = dataset.get("sample").get("shape")
-    job_request.additional_values["sample_height"] = dataset.get("sample").get("height")
-    job_request.additional_values["sample_width"] = dataset.get("sample").get("width")
+    job_request.additional_values["sample_thickness"] = float(dataset.get("sample").get("thickness")[0])
+    job_request.additional_values["sample_geometry"] = str(dataset.get("sample").get("shape")[0]).lstrip("b").strip("'")
+    job_request.additional_values["sample_height"] = float(dataset.get("sample").get("height")[0])
+    job_request.additional_values["sample_width"] = float(dataset.get("sample").get("width")[0])
 
     return job_request
 

--- a/rundetection/rules/loq_rules.py
+++ b/rundetection/rules/loq_rules.py
@@ -100,12 +100,9 @@ def create_list_of_files(job_request: JobRequest) -> list[SansFileData]:
     for run_info in cycle_run_info["NXroot"]["NXentry"]:
         title_contents = run_info["title"]["#text"].split("_")
         run_number = run_info["run_number"]["#text"]
-        if len(title_contents) in {2, 3}:
-            file_type = title_contents[-1]
-        else:
-            job_request.will_reduce = False
-            logger.error(f"Run {run_info} either doesn't contain a _ or is not an expected experiment title format.")
-            return []
+        if len(title_contents) not in {2, 3}:
+            continue
+        file_type = title_contents[-1]
         list_of_files.append(SansFileData(title=run_info["title"]["#text"], type=file_type, run_number=run_number))
     return list_of_files
 

--- a/test/ingestion/test_extracts.py
+++ b/test/ingestion/test_extracts.py
@@ -241,10 +241,10 @@ def test_osiris_extract_raises_on_bad_frequencies(job_request):
 def test_loq_extract(job_request):
     dataset = {
         "sample": {
-            "thickness": 1.0,
-            "shape": "Disc",
-            "height": 8.0,
-            "width": 8.0,
+            "thickness": [1.0],
+            "shape": ["b'Disc'"],
+            "height": [8.0],
+            "width": [8.0],
         }
     }
     with patch("rundetection.ingestion.extracts.get_cycle_string_from_path", return_value="some string"):


### PR DESCRIPTION
Closes None, rush fix for prod as part of BAU

## Description
Some parts were dysfunctional when observed in production instead of the staging environment, this should fix that.