### PR TITLE
Appropriately handle rounding freq vals

### DIFF
--- a/rundetection/rules/osiris_rules.py
+++ b/rundetection/rules/osiris_rules.py
@@ -171,7 +171,7 @@ class OsirisReflectionCalibrationRule(Rule[dict[str, str]]):
     def _determine_reflection(self, job_request: JobRequest) -> str:
         # Magic 50 number determined by knowing that no frequency below 50 uses 004,
         # as per https://www.isis.stfc.ac.uk/Pages/osiris-user-guide.pdf
-        if job_request.additional_values["freq10"] < 50:  # noqa: PLR2004
+        if round(job_request.additional_values["freq10"]) < 50:  # noqa: PLR2004
             return "002"
         return self._determine_reflection_from_tcb_values(
             tcb_detector_min=job_request.additional_values["tcb_detector_min"],

--- a/test/rules/test_osiris_rules.py
+++ b/test/rules/test_osiris_rules.py
@@ -223,6 +223,19 @@ def test_analyser_rule_verify_freq_less_than_50(job_request, reflection_rule):
     assert job_request.additional_values["calibration_run_number"] == "00148587"
 
 
+def test_analyser_rule_verify_freq_less_than_50_but_close(job_request, reflection_rule):
+    """Test correct analyser returned"""
+    job_request.additional_values["mode"] = "spectroscopy"
+    job_request.additional_values["freq10"] = 49.981
+    job_request.additional_values["tcb_detector_min"] = 20500.0
+    job_request.additional_values["tcb_detector_max"]= 40500.0
+    job_request.additional_values["tcb_monitor_min"]= 16700.0
+    job_request.additional_values["tcb_monitor_max"]= 36700.0
+    reflection_rule.verify(job_request)
+    assert job_request.additional_values["reflection"] == "004"
+    assert job_request.additional_values["calibration_run_number"] == "00148587"
+
+
 def test_verify_freq_greater_than_50_valid_tcb(job_request, reflection_rule):
     """Test correct analyser returned"""
     job_request.additional_values = {

--- a/test/rules/test_osiris_rules.py
+++ b/test/rules/test_osiris_rules.py
@@ -228,9 +228,9 @@ def test_analyser_rule_verify_freq_less_than_50_but_close(job_request, reflectio
     job_request.additional_values["mode"] = "spectroscopy"
     job_request.additional_values["freq10"] = 49.981
     job_request.additional_values["tcb_detector_min"] = 20500.0
-    job_request.additional_values["tcb_detector_max"]= 40500.0
-    job_request.additional_values["tcb_monitor_min"]= 16700.0
-    job_request.additional_values["tcb_monitor_max"]= 36700.0
+    job_request.additional_values["tcb_detector_max"] = 40500.0
+    job_request.additional_values["tcb_monitor_min"] = 16700.0
+    job_request.additional_values["tcb_monitor_max"] = 36700.0
     reflection_rule.verify(job_request)
     assert job_request.additional_values["reflection"] == "004"
     assert job_request.additional_values["calibration_run_number"] == "00148587"


### PR DESCRIPTION
Closes #320 

## Description
Adds rounding so that it will handle 49.99999 values as 50 when comparing against 50 for the purposes of determining the graphite reflection for OSIRIS