### PR TITLE
Adjust factory to handle str and int

### DIFF
--- a/rundetection/rules/factory.py
+++ b/rundetection/rules/factory.py
@@ -45,8 +45,8 @@ def rule_factory(key_: str, value: T) -> Rule[Any]:  # noqa: C901, PLR0911, PLR0
             if isinstance(value, str):
                 return MariMaskFileRule(value)
         case "mariwbvan":
-            if isinstance(value, int):
-                return MariWBVANRule(value)
+            if isinstance(value, int | str):
+                return MariWBVANRule(int(value))
         case "osiriscalibfilesandreflection":
             if isinstance(value, dict):
                 return OsirisReflectionCalibrationRule(value)

--- a/test/rules/test_factory.py
+++ b/test/rules/test_factory.py
@@ -71,6 +71,19 @@ def test_rule_factory_returns_correct_rule(rule_key, rule_value, expected_rule):
     assert_correct_rule(rule_key, rule_value, expected_rule)
 
 
+def test_mariwbvan_rule_factory_returns_correct_rule_int_and_str():
+    """
+    Test to ensure that the rule factory returns the correct Rule for MariWBVAN when using either a str or int to create
+    the rule from the specification.
+    """
+    rule = rule_factory("mariwbvan", 12345)
+    assert isinstance(rule, MariWBVANRule)
+    assert rule._value == 12345  # noqa: PLR2004
+    rule = rule_factory("mariwbvan", "12345")
+    assert isinstance(rule, MariWBVANRule)
+    assert rule._value == 12345  # noqa: PLR2004
+
+
 def test_raises_exception_for_missing_rule_class() -> None:
     """
     Test exception raised when non-existent rule name is given


### PR DESCRIPTION
Closes None, fixes bug noticed in production

## Description
Factory currently can't handle a non-int being passed when the frontend sets values as a str